### PR TITLE
PRD-15925 - Added proguard rules for release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,7 +20,6 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# Added the following lines to work Inai SDK in release builds.
 -keepclassmembers class * {
     @android.webkit.JavascriptInterface <methods>;
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,13 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Added the following lines to work Inai SDK in release builds.
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
+
+-keepattributes JavascriptInterface
+
+-dontwarn io.inai.android_sdk.**
+-keep class io.inai.android_sdk.** {*;}


### PR DESCRIPTION
# Ticket: [PRD-15925](https://inai.atlassian.net/browse/PRD-15925)

## Description of changes

>  Added proguard rules to work Inai SDK in release builds when proguard is enabled. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

[PRD-15925]: https://inai.atlassian.net/browse/PRD-15925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ